### PR TITLE
Upgrade OpenAI image generation to gpt-image-2

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -184,7 +184,7 @@ The extension uses a sophisticated three-stage AI processing pipeline with optio
 │  • Builds dynamic prompt from parsed menu data          │
 │  • Includes unified image style (plates + aesthetics)   │
 │  • AI generates photorealistic visualization            │
-│  • (GPT-Image-1.5 or Gemini 3 Pro Image)               │
+│  • (gpt-image-2 or Gemini 3 Pro Image)                  │
 └─────────────────────────────────────────────────────────┘
                         ↓
 ┌─────────────────────────────────────────────────────────┐

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <img src="images/verkadalizer.png" alt="Verkadalizer Chrome Extension"/>
 
-A Chrome extension that transforms food menu images on Verkada Menu pages into beautiful, appetizing visualizations using a sophisticated two-stage AI pipeline powered by OpenAI (GPT-4o + GPT-Image-1.5) or Google Gemini (Gemini 3 Pro + Gemini 3 Pro Image).
+A Chrome extension that transforms food menu images on Verkada Menu pages into beautiful, appetizing visualizations using a sophisticated two-stage AI pipeline powered by OpenAI (GPT-4o + gpt-image-2) or Google Gemini (Gemini 3 Pro + Gemini 3 Pro Image).
 
 ## Features
 
@@ -14,7 +14,7 @@ A Chrome extension that transforms food menu images on Verkada Menu pages into b
     - **OpenAI**: GPT-4o vision model
     - **Google Gemini**: Gemini 3 Pro
   - **Stage 2**: AI generates a photorealistic visualization of the selected dishes
-    - **OpenAI**: GPT-Image-1.5 for high-quality image generation
+    - **OpenAI**: gpt-image-2 for high-quality image generation with agentic reasoning and accurate text rendering
     - **Google Gemini**: Gemini 3 Pro Image for professional 2K/4K image generation with superior text rendering
 - **Smart Image Controls**: Interactive buttons for each menu image:
   - ✨🍕 **Generate** - Process the menu image with AI
@@ -100,7 +100,7 @@ Translate menu text into multiple languages while preserving the original layout
 Click the extension icon to access settings:
 
 - **AI Provider**: Choose between OpenAI or Google Gemini
-  - **OpenAI**: Uses GPT-4o for menu analysis and GPT-Image-1.5 for image generation
+  - **OpenAI**: Uses GPT-4o for menu analysis and gpt-image-2 for image generation
   - **Google Gemini**: Uses Gemini 3 Pro for menu analysis and Gemini 3 Pro Image for generation
 - **API Key**: Your personal API key for the selected provider (stored securely in local browser storage)
   - **OpenAI API Key**: Required when using OpenAI provider
@@ -145,7 +145,7 @@ Using the parsed menu data and selected image style:
   - Photorealism requirements (textures, lighting, organic presentation)
   - **Optional Translation**: If translation is enabled, AI translates menu text while preserving original layout/typography
 - Sends to your selected AI provider for image creation:
-  - **OpenAI**: GPT-Image-1.5 for high-quality photorealistic images
+  - **OpenAI**: gpt-image-2 for high-quality photorealistic images (released April 2026, with agentic reasoning and high-fidelity input handling by default)
   - **Google Gemini**: Gemini 3 Pro Image for professional 2K resolution with native text rendering and "thinking mode" for optimal composition
 - Receives professional-quality food photography visualization in your chosen unified style
 - **Translation Processing** (if enabled):
@@ -178,7 +178,7 @@ Using the parsed menu data and selected image style:
 #### OpenAI Provider
 
 - **GPT-4o**: Vision-based menu text analysis and intelligent dish selection
-- **GPT-Image-1.5**: High-quality photorealistic image generation with advanced control
+- **gpt-image-2**: High-quality photorealistic image generation with agentic reasoning, accurate multilingual text rendering, and automatic high-fidelity input processing
 
 #### Google Gemini Provider
 

--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ Click the extension icon to access settings:
   - **Gemini API Key**: Required when using Google Gemini provider
 - **Dietary Preference**: Select your dietary preference from 8 options (affects dish selection in Stage 1)
 - **Image Style**: Choose a unified style preset (plates stay corporate Verkada; composition/rendering varies by style)
+- **Image Quality**: ⚡ Fast / ⚖️ Balanced / 💎 High — controls the OpenAI `quality` param for gpt-image-2 (default: Balanced; ignored by Gemini)
 - **Translation Language**: Translate menu text into 12 languages while preserving original layout (default: No Translation)
 
 ## How It Works

--- a/ai/prompts/menu-food-generation.js
+++ b/ai/prompts/menu-food-generation.js
@@ -40,6 +40,36 @@ function buildNoTextConstraintSection() {
   `;
 }
 
+function buildFoodAuthenticitySection() {
+  // gpt-image-2 follows the styling sections very literally and tends to
+  // produce Michelin-tier plating unless we explicitly anchor the food itself
+  // to a workplace-cafeteria register. The cinematography / lighting /
+  // background stay polished — only the FOOD itself is constrained here.
+  return dedent`
+    ### FOOD AUTHENTICITY (CRITICAL)
+    The food is from a WORKPLACE CAFETERIA / EMPLOYEE CANTEEN — not a fine-dining restaurant.
+    Render the dishes as REAL, hearty, recognizable cafeteria food that an employee would actually be served at lunch.
+
+    **DO:**
+    - Generous, normal lunch-size portions (filling, not tasting-menu sized)
+    - Honest, recognizable plating — food looks like food, not sculpture
+    - Casual home-style / canteen / catering-tray presentation
+    - Real ingredients in their natural form: visible noodles, chunks of meat, whole vegetables, normal sauces, ladled-on toppings
+    - Slightly imperfect, lived-in plating is fine and preferred over perfection
+
+    **AVOID — fine-dining tells that DO NOT belong here:**
+    - Tweezer-plated micro-portions, tiny dollops, smears, swooshes, quenelles
+    - Microgreens, edible flowers, gold leaf, tweezed herbs as garnish
+    - Foams, gels, powders, dehydrated dusts, molecular-gastronomy spheres
+    - Architecturally stacked or sculpted food, deconstructed presentation
+    - Plates with vast negative space and one tiny element in the center
+    - Michelin / haute-cuisine / tasting-menu / fine-dining aesthetics
+
+    Cinematography (lighting, optics, background) may be polished, but the
+    FOOD ITSELF should look like what you'd actually pick up on a cafeteria tray.
+  `;
+}
+
 function buildNegativePromptsSection(styleNegatives = '') {
   // Named section to make it obvious what is "rules" vs "avoid list".
   return dedent`
@@ -290,6 +320,7 @@ export function buildMenuFoodGenerationPrompt(
       `,
       buildNoTextConstraintSection(),
       buildNegativePromptsSection(styleNegatives),
+      buildFoodAuthenticitySection(),
       dedent`
         ## MENU THEME CONTEXT
         ${menuTheme}
@@ -354,6 +385,7 @@ export function buildMenuFoodGenerationPrompt(
       `,
       buildNoTextConstraintSection(),
       buildNegativePromptsSection(styleNegatives),
+      buildFoodAuthenticitySection(),
       dedent`
         ## MENU THEME CONTEXT
         ${menuTheme}
@@ -417,6 +449,7 @@ export function buildMenuFoodGenerationPrompt(
       `,
       buildNoTextConstraintSection(),
       buildNegativePromptsSection(styleNegatives),
+      buildFoodAuthenticitySection(),
       dedent`
         ## MENU THEME CONTEXT
         ${menuTheme}
@@ -479,6 +512,7 @@ export function buildMenuFoodGenerationPrompt(
       `,
       buildNoTextConstraintSection(),
       buildNegativePromptsSection(styleNegatives),
+      buildFoodAuthenticitySection(),
       dedent`
         ## MENU THEME CONTEXT
         ${menuTheme}
@@ -540,6 +574,7 @@ export function buildMenuFoodGenerationPrompt(
       `,
       buildNoTextConstraintSection(),
       buildNegativePromptsSection(styleNegatives),
+      buildFoodAuthenticitySection(),
       dedent`
         ## MENU THEME CONTEXT
         ${menuTheme}
@@ -596,10 +631,12 @@ export function buildMenuFoodGenerationPrompt(
   return joinSections([
     dedent`
       ## PRIMARY OBJECTIVE
-      Generate a photorealistic, studio-grade professional food photography scene featuring exactly ${selectedItems.length} dishes.
+      Generate a photorealistic, well-lit food photography scene of exactly ${selectedItems.length} workplace-cafeteria dishes.
+      Cinematography (lighting, optics, background) is polished, but the food itself is real cafeteria food — see FOOD AUTHENTICITY below.
     `,
     buildNoTextConstraintSection(),
     buildNegativePromptsSection(styleNegatives),
+    buildFoodAuthenticitySection(),
     dedent`
       ## MENU THEME CONTEXT
       ${menuTheme}

--- a/ai/providers/ai-providers.js
+++ b/ai/providers/ai-providers.js
@@ -94,6 +94,7 @@ export function getImageGenerator(providerType = 'openai') {
  * @param {string} params.apiKey - API key
  * @param {AbortSignal} params.signal - Abort signal
  * @param {string} params.providerType - Provider type (default: 'openai')
+ * @param {string} [params.imageQuality] - 'low' | 'medium' | 'high' (OpenAI only; ignored by Gemini)
  * @returns {Promise<string>} Base64 encoded image
  */
 export async function generateImageWithAI({
@@ -101,7 +102,8 @@ export async function generateImageWithAI({
   imageBlob,
   apiKey,
   signal,
-  providerType = 'openai'
+  providerType = 'openai',
+  imageQuality
 }) {
   const generator = getImageGenerator(providerType);
 
@@ -110,6 +112,7 @@ export async function generateImageWithAI({
     imageBlob,
     apiKey,
     signal,
+    imageQuality,
   });
 }
 
@@ -130,6 +133,7 @@ export function getMenuTranslator(providerType = 'openai') {
  * @param {string} params.apiKey - API key
  * @param {AbortSignal} params.signal - Abort signal
  * @param {string} params.providerType - Provider type (default: 'openai')
+ * @param {string} [params.imageQuality] - 'low' | 'medium' | 'high' (OpenAI only; ignored by Gemini)
  * @returns {Promise<string>} Base64 encoded translated menu image
  */
 export async function translateMenuImageWithAI({
@@ -137,8 +141,9 @@ export async function translateMenuImageWithAI({
   imageBlob,
   apiKey,
   signal,
-  providerType = 'openai'
+  providerType = 'openai',
+  imageQuality
 }) {
   const translator = getMenuTranslator(providerType);
-  return translator({ prompt, imageBlob, apiKey, signal });
+  return translator({ prompt, imageBlob, apiKey, signal, imageQuality });
 }

--- a/ai/providers/openai-provider.js
+++ b/ai/providers/openai-provider.js
@@ -18,8 +18,8 @@ import { logInfo, logWarn, logError } from '../../lib/logger.js';
 // ============================================================================
 
 const MODELS = {
-  parse: 'gpt-4o',           // Menu parsing (vision + JSON)
-  image: 'gpt-image-1.5',    // Image generation/editing (upgraded Dec 2025)
+  parse: 'gpt-4o',          // Menu parsing (vision + JSON)
+  image: 'gpt-image-2',     // Image generation/editing (released Apr 2026)
 };
 
 // ============================================================================
@@ -28,7 +28,10 @@ const MODELS = {
 
 
 /**
- * OpenAI GPT-Image-1.5 supported sizes for edits endpoint
+ * OpenAI gpt-image-2 sizes used for the edits endpoint.
+ * gpt-image-2 accepts arbitrary resolutions (multiples of 16, up to 3840px on
+ * the longest edge), but we lock to these three so that the output matches the
+ * common menu aspect ratios — square, landscape 3:2, portrait 2:3.
  */
 const OPENAI_IMAGE_SIZES = [
   { width: 1024, height: 1024, ratio: 1.000, name: '1024x1024' },     // Square
@@ -172,7 +175,7 @@ export async function parseMenuWithOpenAI({ imageUrl, dietaryPreference, apiKey,
 }
 
 /**
- * Generate menu image with OpenAI GPT-Image-1.5
+ * Generate menu image with OpenAI gpt-image-2
  * @param {Object} params - Parameters
  * @param {string} params.prompt - Image generation prompt
  * @param {Blob} params.imageBlob - Image blob for reference
@@ -193,12 +196,12 @@ export async function generateMenuImageWithOpenAI({ prompt, imageBlob, apiKey, s
     const dimensions = await getImageDimensions(imageBlob);
     const size = selectOpenAISize(dimensions.width, dimensions.height);
 
-    // Build request for GPT-Image-1.5
+    // gpt-image-2 always processes inputs at high fidelity, so input_fidelity
+    // is no longer accepted.
     const formData = new FormData();
     formData.append('model', modelName);
     formData.append('prompt', prompt);
     formData.append('n', '1');
-    formData.append('input_fidelity', 'high');
     formData.append('quality', 'high');
     formData.append('size', size);
     formData.append('image', imageBlob, 'image.png');
@@ -234,7 +237,7 @@ export async function generateMenuImageWithOpenAI({ prompt, imageBlob, apiKey, s
 }
 
 /**
- * Translate menu image with OpenAI GPT-Image-1.5 (layout-preserving translation)
+ * Translate menu image with OpenAI gpt-image-2 (layout-preserving translation)
  * This is a dedicated entrypoint so the pipeline can run translation in parallel with food generation.
  *
  * @param {Object} params - Parameters

--- a/ai/providers/openai-provider.js
+++ b/ai/providers/openai-provider.js
@@ -39,8 +39,22 @@ const OPENAI_IMAGE_SIZES = [
   { width: 1024, height: 1536, ratio: 0.667, name: '1024x1536' }      // Portrait
 ];
 
+const VALID_QUALITIES = new Set(['low', 'medium', 'high']);
+
 /**
- * Select optimal OpenAI image size based on input image aspect ratio
+ * Penalty applied to non-square sizes when picking the closest aspect ratio.
+ * 1024x1024 has ~2.25x fewer pixels than 1536x1024, so square renders meaningfully
+ * faster on gpt-image-2. The result is downscaled into the page DOM anyway, so
+ * for near-square menus the larger rectangle rarely adds visible value. The
+ * penalty shifts the crossover so square wins for any ratio in roughly
+ * [0.74, 1.35], and only clearly landscape / portrait menus pay for the bigger size.
+ */
+const NON_SQUARE_SIZE_PENALTY = 0.2;
+
+/**
+ * Select optimal OpenAI image size based on input image aspect ratio.
+ * Biased toward 1024x1024 because pixel count drives gpt-image-2 latency.
+ *
  * @param {number} width - Input image width
  * @param {number} height - Input image height
  * @returns {string} Best matching size (e.g., '1536x1024')
@@ -53,7 +67,9 @@ function selectOpenAISize(width, height) {
   let smallestDifference = Infinity;
 
   for (const size of OPENAI_IMAGE_SIZES) {
-    const difference = Math.abs(targetRatio - size.ratio);
+    const baseDiff = Math.abs(targetRatio - size.ratio);
+    const penalty = size.ratio === 1 ? 0 : NON_SQUARE_SIZE_PENALTY;
+    const difference = baseDiff + penalty;
     if (difference < smallestDifference) {
       smallestDifference = difference;
       closestSize = size;
@@ -181,11 +197,13 @@ export async function parseMenuWithOpenAI({ imageUrl, dietaryPreference, apiKey,
  * @param {Blob} params.imageBlob - Image blob for reference
  * @param {string} params.apiKey - OpenAI API key
  * @param {AbortSignal} params.signal - Abort signal
+ * @param {string} [params.imageQuality] - 'low' | 'medium' | 'high' (default 'medium')
  * @returns {Promise<string>} Base64 encoded image
  */
-export async function generateMenuImageWithOpenAI({ prompt, imageBlob, apiKey, signal }) {
+export async function generateMenuImageWithOpenAI({ prompt, imageBlob, apiKey, signal, imageQuality }) {
   const modelName = MODELS.image;
-  logInfo('provider', 'openai', `Starting image generation with ${modelName}`);
+  const quality = VALID_QUALITIES.has(imageQuality) ? imageQuality : 'medium';
+  logInfo('provider', 'openai', `Starting image generation with ${modelName} (quality=${quality})`);
 
   try {
     if (!apiKey) {
@@ -202,7 +220,7 @@ export async function generateMenuImageWithOpenAI({ prompt, imageBlob, apiKey, s
     formData.append('model', modelName);
     formData.append('prompt', prompt);
     formData.append('n', '1');
-    formData.append('quality', 'high');
+    formData.append('quality', quality);
     formData.append('size', size);
     formData.append('image', imageBlob, 'image.png');
 
@@ -245,9 +263,10 @@ export async function generateMenuImageWithOpenAI({ prompt, imageBlob, apiKey, s
  * @param {Blob} params.imageBlob - Original menu image blob (reference)
  * @param {string} params.apiKey - OpenAI API key
  * @param {AbortSignal} params.signal - Abort signal
+ * @param {string} [params.imageQuality] - 'low' | 'medium' | 'high' (default 'medium')
  * @returns {Promise<string>} Base64 encoded translated menu image
  */
-export async function translateMenuImageWithOpenAI({ prompt, imageBlob, apiKey, signal }) {
+export async function translateMenuImageWithOpenAI({ prompt, imageBlob, apiKey, signal, imageQuality }) {
   // Same endpoint/model as generation; prompt differs (text-only translation image).
-  return generateMenuImageWithOpenAI({ prompt, imageBlob, apiKey, signal });
+  return generateMenuImageWithOpenAI({ prompt, imageBlob, apiKey, signal, imageQuality });
 }

--- a/background.js
+++ b/background.js
@@ -105,6 +105,7 @@ async function processImageRequest({ imageUrl, requestId, signal }) {
     const settingsKeys = [
       STORAGE_KEYS.SETTINGS.DIETARY_PREFERENCE,
       STORAGE_KEYS.SETTINGS.IMAGE_STYLE,
+      STORAGE_KEYS.SETTINGS.IMAGE_QUALITY,
       STORAGE_KEYS.SETTINGS.MENU_LANGUAGE,
       LEGACY_KEYS.DIETARY_PREFERENCE,
       LEGACY_KEYS.IMAGE_STYLE,
@@ -119,6 +120,8 @@ async function processImageRequest({ imageUrl, requestId, signal }) {
       || stored[LEGACY_KEYS.IMAGE_STYLE]
       || 'verkada-classic';
     const normalizedImageStyle = normalizeImageStyleId(imageStyle);
+    // gpt-image-2 quality knob — 'medium' is the default sweet spot post-upgrade.
+    const imageQuality = stored[STORAGE_KEYS.SETTINGS.IMAGE_QUALITY] || 'medium';
     const menuLanguage = stored[STORAGE_KEYS.SETTINGS.MENU_LANGUAGE]
       || stored[LEGACY_KEYS.MENU_LANGUAGE]
       || 'none';
@@ -223,7 +226,8 @@ async function processImageRequest({ imageUrl, requestId, signal }) {
       imageBlob,
       apiKey: settings.apiKey,
       signal,
-      providerType: settings.aiProvider
+      providerType: settings.aiProvider,
+      imageQuality,
     });
 
     const translationPromise = isTranslationEnabled
@@ -232,7 +236,8 @@ async function processImageRequest({ imageUrl, requestId, signal }) {
         imageBlob,
         apiKey: settings.apiKey,
         signal,
-        providerType: settings.aiProvider
+        providerType: settings.aiProvider,
+        imageQuality,
       }).catch((err) => {
         logWarn('background', 'pipeline', 'Menu translation failed, using original layer', err?.message || err);
         return null;

--- a/lib/storage-keys.js
+++ b/lib/storage-keys.js
@@ -12,6 +12,7 @@ export const STORAGE_KEYS = {
     AI_PROVIDER: 'vk.settings.aiProvider',
     DIETARY_PREFERENCE: 'vk.settings.dietaryPreference',
     IMAGE_STYLE: 'vk.settings.imageStyle',
+    IMAGE_QUALITY: 'vk.settings.imageQuality',
     MENU_LANGUAGE: 'vk.settings.menuLanguage',
   },
 
@@ -128,6 +129,7 @@ export function getAllSettingsKeys() {
     STORAGE_KEYS.SETTINGS.AI_PROVIDER,
     STORAGE_KEYS.SETTINGS.DIETARY_PREFERENCE,
     STORAGE_KEYS.SETTINGS.IMAGE_STYLE,
+    STORAGE_KEYS.SETTINGS.IMAGE_QUALITY,
     STORAGE_KEYS.SETTINGS.MENU_LANGUAGE,
     STORAGE_KEYS.API_KEYS.OPENAI,
     STORAGE_KEYS.API_KEYS.GEMINI,

--- a/popup.html
+++ b/popup.html
@@ -143,6 +143,16 @@
     <div class="info">Changes plates and photography style</div>
   </div>
 
+  <div class="section" id="imageQualitySection">
+    <label for="imageQuality">Image Quality:</label>
+    <select id="imageQuality">
+      <option value="low">⚡ Fast</option>
+      <option value="medium">⚖️ Balanced</option>
+      <option value="high">💎 High</option>
+    </select>
+    <div class="info">Higher quality is slower (OpenAI only)</div>
+  </div>
+
   <div class="section">
     <label for="menuLanguage">
       Menu Language

--- a/popup.html
+++ b/popup.html
@@ -9,32 +9,32 @@
 
     body {
       width: 300px;
-      padding: 20px;
+      padding: 14px 20px;
       font-family: Arial, sans-serif;
       margin: 0;
     }
-    
+
     h1 {
       font-size: 18px;
-      margin: 0 0 15px 0;
+      margin: 0 0 10px 0;
       color: #333;
     }
-    
+
     .section {
-      margin-bottom: 15px;
+      margin-bottom: 10px;
     }
-    
+
     label {
       display: block;
-      margin-bottom: 5px;
+      margin-bottom: 4px;
       font-weight: bold;
       color: #555;
     }
-    
+
     input, textarea, select {
       width: 100%;
       box-sizing: border-box;
-      padding: 8px;
+      padding: 6px 8px;
       border: 1px solid #ddd;
       border-radius: 4px;
       font-size: 14px;
@@ -46,12 +46,12 @@
     }
     
     button {
-      padding: 10px 15px;
+      padding: 8px 15px;
       border-radius: 4px;
       cursor: pointer;
       font-size: 14px;
       width: 100%;
-      margin-top: 10px;
+      margin-top: 6px;
     }
 
     button.primary {
@@ -95,7 +95,7 @@
     .info {
       font-size: 12px;
       color: #666;
-      margin-top: 5px;
+      margin-top: 3px;
     }
 
     .beta-badge {

--- a/popup.js
+++ b/popup.js
@@ -99,7 +99,7 @@ function populateAiProviders(providerInput, providers) {
   }
 }
 
-async function loadSettingsIntoUi(aiProviderInput, openaiApiKeyInput, geminiApiKeyInput, dietaryPreferenceInput, imageStyleInput, menuLanguageInput) {
+async function loadSettingsIntoUi(aiProviderInput, openaiApiKeyInput, geminiApiKeyInput, dietaryPreferenceInput, imageStyleInput, imageQualityInput, menuLanguageInput) {
   const aiProviders = await loadAiProviders();
   populateAiProviders(aiProviderInput, aiProviders);
 
@@ -117,6 +117,7 @@ async function loadSettingsIntoUi(aiProviderInput, openaiApiKeyInput, geminiApiK
     STORAGE_KEYS.SETTINGS.AI_PROVIDER,
     STORAGE_KEYS.SETTINGS.DIETARY_PREFERENCE,
     STORAGE_KEYS.SETTINGS.IMAGE_STYLE,
+    STORAGE_KEYS.SETTINGS.IMAGE_QUALITY,
     STORAGE_KEYS.SETTINGS.MENU_LANGUAGE,
     STORAGE_KEYS.API_KEYS.OPENAI,
     STORAGE_KEYS.API_KEYS.GEMINI,
@@ -188,6 +189,12 @@ async function loadSettingsIntoUi(aiProviderInput, openaiApiKeyInput, geminiApiK
     menuLanguageInput.value = selectedMenuLanguage;
   }
 
+  // gpt-image-2 is materially slower than gpt-image-1.5 at quality=high because of
+  // its agentic-reasoning pass, so default to 'medium' for new installs. Existing
+  // users who want the slower/sharper default can pick "High" explicitly.
+  const selectedImageQuality = stored[STORAGE_KEYS.SETTINGS.IMAGE_QUALITY] || 'medium';
+  imageQualityInput.value = selectedImageQuality;
+
   // Show/hide appropriate API key section
   toggleApiKeySection(selectedProvider);
 }
@@ -205,12 +212,13 @@ function toggleApiKeySection(provider) {
   }
 }
 
-async function saveSettings(aiProviderInput, openaiApiKeyInput, geminiApiKeyInput, dietaryPreferenceInput, imageStyleInput, menuLanguageInput, statusDiv) {
+async function saveSettings(aiProviderInput, openaiApiKeyInput, geminiApiKeyInput, dietaryPreferenceInput, imageStyleInput, imageQualityInput, menuLanguageInput, statusDiv) {
   const aiProvider = aiProviderInput.value.trim();
   const openaiApiKey = openaiApiKeyInput.value.trim();
   const geminiApiKey = geminiApiKeyInput.value.trim();
   const dietaryPreference = dietaryPreferenceInput.value.trim();
   const imageStyle = normalizeImageStyleId(imageStyleInput.value.trim());
+  const imageQuality = imageQualityInput.value.trim();
   const menuLanguage = menuLanguageInput.value.trim();
 
   // Validate that the selected provider has an API key
@@ -228,6 +236,7 @@ async function saveSettings(aiProviderInput, openaiApiKeyInput, geminiApiKeyInpu
       [STORAGE_KEYS.SETTINGS.AI_PROVIDER]: aiProvider,
       [STORAGE_KEYS.SETTINGS.DIETARY_PREFERENCE]: dietaryPreference,
       [STORAGE_KEYS.SETTINGS.IMAGE_STYLE]: imageStyle,
+      [STORAGE_KEYS.SETTINGS.IMAGE_QUALITY]: imageQuality,
       [STORAGE_KEYS.SETTINGS.MENU_LANGUAGE]: menuLanguage,
       [STORAGE_KEYS.API_KEYS.OPENAI]: openaiApiKey,
       [STORAGE_KEYS.API_KEYS.GEMINI]: geminiApiKey,
@@ -244,40 +253,45 @@ document.addEventListener('DOMContentLoaded', async () => {
   const geminiApiKeyInput = document.getElementById('geminiApiKey');
   const dietaryPreferenceInput = document.getElementById('dietaryPreference');
   const imageStyleInput = document.getElementById('imageStyle');
+  const imageQualityInput = document.getElementById('imageQuality');
   const menuLanguageInput = document.getElementById('menuLanguage');
   const menuLinkBtn = document.getElementById('menuLink');
   const statusDiv = document.getElementById('status');
 
-  // Handle AI provider change
+  const persist = () => saveSettings(
+    aiProviderInput,
+    openaiApiKeyInput,
+    geminiApiKeyInput,
+    dietaryPreferenceInput,
+    imageStyleInput,
+    imageQualityInput,
+    menuLanguageInput,
+    statusDiv,
+  );
+
   aiProviderInput.addEventListener('change', async () => {
     toggleApiKeySection(aiProviderInput.value);
-    await saveSettings(aiProviderInput, openaiApiKeyInput, geminiApiKeyInput, dietaryPreferenceInput, imageStyleInput, menuLanguageInput, statusDiv);
+    await persist();
   });
 
-  // Auto-save on input change
-  openaiApiKeyInput.addEventListener('input', async () => {
-    await saveSettings(aiProviderInput, openaiApiKeyInput, geminiApiKeyInput, dietaryPreferenceInput, imageStyleInput, menuLanguageInput, statusDiv);
-  });
-
-  geminiApiKeyInput.addEventListener('input', async () => {
-    await saveSettings(aiProviderInput, openaiApiKeyInput, geminiApiKeyInput, dietaryPreferenceInput, imageStyleInput, menuLanguageInput, statusDiv);
-  });
-
-  dietaryPreferenceInput.addEventListener('change', async () => {
-    await saveSettings(aiProviderInput, openaiApiKeyInput, geminiApiKeyInput, dietaryPreferenceInput, imageStyleInput, menuLanguageInput, statusDiv);
-  });
-
-  imageStyleInput.addEventListener('change', async () => {
-    await saveSettings(aiProviderInput, openaiApiKeyInput, geminiApiKeyInput, dietaryPreferenceInput, imageStyleInput, menuLanguageInput, statusDiv);
-  });
-
-  menuLanguageInput.addEventListener('change', async () => {
-    await saveSettings(aiProviderInput, openaiApiKeyInput, geminiApiKeyInput, dietaryPreferenceInput, imageStyleInput, menuLanguageInput, statusDiv);
-  });
+  openaiApiKeyInput.addEventListener('input', persist);
+  geminiApiKeyInput.addEventListener('input', persist);
+  dietaryPreferenceInput.addEventListener('change', persist);
+  imageStyleInput.addEventListener('change', persist);
+  imageQualityInput.addEventListener('change', persist);
+  menuLanguageInput.addEventListener('change', persist);
 
   menuLinkBtn.addEventListener('click', () => {
     chrome.tabs.create({ url: 'https://sites.google.com/verkada.com/verkada-menu' });
   });
 
-  await loadSettingsIntoUi(aiProviderInput, openaiApiKeyInput, geminiApiKeyInput, dietaryPreferenceInput, imageStyleInput, menuLanguageInput);
+  await loadSettingsIntoUi(
+    aiProviderInput,
+    openaiApiKeyInput,
+    geminiApiKeyInput,
+    dietaryPreferenceInput,
+    imageStyleInput,
+    imageQualityInput,
+    menuLanguageInput,
+  );
 });


### PR DESCRIPTION
## Summary

Migrates the OpenAI image pipeline to **gpt-image-2** end-to-end. Three commits, framed as one coherent migration:

1. **Model swap** — `gpt-image-1.5` → `gpt-image-2`, `input_fidelity` removed (rejected by the new model; gpt-image-2 always processes inputs at high fidelity).
2. **Prompt rebalance for cafeteria authenticity** — gpt-image-2's agentic reasoning takes the existing `premium` / `studio-grade` / `museum-grade` styling cues much more literally and was producing Michelin-tier plating. Adds a shared `FOOD AUTHENTICITY` section to all six layouts that anchors the food itself to workplace-cafeteria style (generous portions, honest plating, no tweezer plating / microgreens / foams / deconstructed presentation). Cinematography sections are intentionally untouched — image quality itself improved.
3. **Latency mitigations** — gpt-image-2 is materially slower than gpt-image-1.5 at `quality=high` because of its agentic-reasoning step. Two knobs to claw it back:
    - **Image Quality picker (Fast / Balanced / High)** in the popup, default Balanced. New setting `vk.settings.imageQuality`, threaded through `popup.{html,js}` → `background.js` → `ai-providers.js` → `openai-provider.js`. Gemini ignores the value.
    - **Bias `selectOpenAISize` toward 1024×1024.** Pixel count drives gpt-image-2 latency, and the result is downscaled into the page DOM anyway. A 0.2 penalty on non-square sizes shifts the crossover so square wins for any ratio in roughly [0.74, 1.35]; 1536×1024 / 1024×1536 only kick in for clearly landscape / portrait menus.

## What's unchanged

- Endpoint (`/v1/images/edits`), response shape (`data[0].b64_json`), `n=1`, all three sizes (`1024x1024`, `1536x1024`, `1024x1536`).
- No manifest / host-permission changes.
- Translation pipeline still runs in parallel with food generation via `Promise.all`.

## Out of scope (follow-up)

- `partial_images` SSE streaming — gpt-image-2 supports 0–3 progressive snapshots. Doesn't reduce total time but would let us show a preview within ~10–15s instead of waiting on a spinner. Requires SSE parsing in the provider plus message-protocol changes; structurally larger and worth its own PR.

## Test plan

- [ ] Reload the unpacked extension at `chrome://extensions`
- [ ] Open the Verkada Menu page and click ✨🍕 Generate on a menu image
- [ ] Inspect the service worker (chrome://extensions → Service worker → Network) and confirm the `/v1/images/edits` request body contains `model=gpt-image-2`, no `input_fidelity`, and the selected `quality` value
- [ ] Pop the extension popup → verify the new **Image Quality** dropdown appears, defaults to ⚖️ Balanced, persists across reloads
- [ ] Run Generate at each of Fast / Balanced / High; confirm wall-time differences and visible quality differences match expectations
- [ ] Generated food looks like cafeteria food (generous portions, no tweezer plating / microgreens / foams)
- [ ] Translation flow still works in parallel; non-Latin target language (e.g., Japanese) renders legibly
- [ ] Near-square menus get `1024x1024` (check the service-worker log line `Image config: …`); strongly landscape menus still get `1536x1024`

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)