### PR TITLE
ci(release): bump release-workflow actions to Node 24 majors

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Verify manifest version matches tag
         run: |
@@ -58,7 +58,7 @@ jobs:
           ls -lh "$ZIP_NAME"
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           name: v${{ env.VERSION }}
           generate_release_notes: true
@@ -66,7 +66,7 @@ jobs:
 
       - name: Publish to Chrome Web Store
         if: ${{ vars.CHROME_PUBLISH == 'true' }}
-        uses: mnao305/chrome-extension-upload@v5.0.0
+        uses: mnao305/chrome-extension-upload@v6
         continue-on-error: true
         with:
           file-path: ${{ env.ZIP_NAME }}


### PR DESCRIPTION
## Summary

Address the Node.js 20 deprecation warning surfaced on the v4.1.0 release run. GitHub removes Node 20 from runners on **2026-09-16** and forces Node 24 by default on **2026-06-02**. All three pinned actions in `release.yml` shipped Node-24-only majors recently, with no other behavioral changes.

| Action | Old | New | Notes |
|---|---|---|---|
| `actions/checkout` | `@v4` | `@v6` | v5 was the Node 24 cut, v6 is current; same inputs |
| `softprops/action-gh-release` | `@v2` | `@v3` | Release notes confirm Node 24 is the only change |
| `mnao305/chrome-extension-upload` | `@v5.0.0` | `@v6` | Major bump is the Node 24 upgrade per release notes |

Pinning floating majors so future patch fixes land automatically.

## Test plan

- [ ] Merge → next `v*` tag push runs the workflow against Node 24 and the deprecation annotation no longer appears
- [ ] CWS upload still reports `uploadState: 'SUCCESS'` (smoke test on next release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)